### PR TITLE
add support for exec and mount binding

### DIFF
--- a/sdk/testcontainers-vault/src/options.ts
+++ b/sdk/testcontainers-vault/src/options.ts
@@ -1,3 +1,4 @@
+
 /**
  * Options for configuring a local Vault instance.
  */
@@ -24,4 +25,24 @@ export type VaultOptions = Partial<{
    * The environment variables to pass to the Vault container.
    */
   env: Record<string, string | number | boolean>;
+
+
+  /**
+   * The volumes to mount in the Vault container.
+   */
+  bindMounts: BindMount[];
 }>
+
+/**
+ * A bind mount mode.
+ */
+export type BindMode = "rw" | "ro" | "z" | "Z";
+
+/**
+ * A bind mount.
+ */
+export type BindMount = {
+  source: string;
+  target: string;
+  mode?: BindMode;
+};

--- a/sdk/testcontainers-vault/test/resources/test-collection.pvschema
+++ b/sdk/testcontainers-vault/test/resources/test-collection.pvschema
@@ -1,0 +1,6 @@
+customers PERSONS (
+  ssn SSN UNIQUE COMMENT 'Social security number',
+  email EMAIL,
+  phone_number PHONE_NUMBER NULL,
+  zip_code_us ZIP_CODE_US NULL,
+);


### PR DESCRIPTION
Add to `@piiano/testcontainers-vault` support for mount binding and exec of commands on the container.
This can allow using the Vault CLI that is available on the vault container more easily.