### PR TITLE
fix wrong dependency in testcontainers-vault

### DIFF
--- a/sdk/testcontainers-vault/package.json
+++ b/sdk/testcontainers-vault/package.json
@@ -26,7 +26,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "testcontainers": "^9.5.0"
+    "testcontainers": "^9.8.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",

--- a/sdk/testcontainers-vault/yarn.lock
+++ b/sdk/testcontainers-vault/yarn.lock
@@ -1116,7 +1116,7 @@ tar-stream@^2.0.0, tar-stream@^2.1.4, tar-stream@^2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-testcontainers@^9.5.0:
+testcontainers@^9.8.0:
   version "9.8.0"
   resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-9.8.0.tgz#03d8798ad047e7673e934934b5504bc0a2f14e4e"
   integrity sha512-61IlJeVrUbS5JlAgM/N0koFnRxsID+vDap7CUmgaHXSGxmFofCiokB7kD96c1BtDWGOznrd7lTAPGSkd3RVkPA==


### PR DESCRIPTION
- add support for exec and mount binding
- fix dependency
