### PR TITLE
export vault client in the forms sdk

### DIFF
--- a/sdk/forms/src/index.ts
+++ b/sdk/forms/src/index.ts
@@ -1,5 +1,6 @@
 import { createProtectedForm } from './protected-forms';
 import { controlForm } from './controlled-forms';
+import { VaultClient as Client } from '@piiano/vault-client';
 
 declare global {
   interface Window {
@@ -10,6 +11,7 @@ declare global {
 export const pvault = {
   createProtectedForm,
   controlForm,
+  Client,
 };
 
 // add pvault to global scope so client can configure use it.


### PR DESCRIPTION
This allow using the Vault client directly with the forms SDK.
The client is the exact same client defined in [@piiano/vault-client](https://github.com/piiano/vault-typescript/tree/main/sdk/vault-client) and as the same methods and parameters.
Only the initialization of the client is a bit different so instead of `new VaultClient()` we export it under the `pvault` global so it will look like `new pvault.Client()`.

Example:
```javascript
const client = new pvault.Client({
  vaultURL: 'https://vault.example.com:8123',
  apiKey: 'vaultApiKey',
});

const version = await client.system.getVaultVersion();
```