### PR TITLE
oris/fix accidental version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.vault_version != 'none'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/sdk/react-forms/README.md
+++ b/sdk/react-forms/README.md
@@ -23,7 +23,7 @@ It allows you to collect sensitive data such as credit card information, social 
 
 > **Note:**
 >
-> This package is compatible with Vault version none.
+> This package is compatible with Vault version 1.11.0.
 > For a version compatible with other versions of Vault, check [other versions of this package](https://www.npmjs.com/package/@piiano/react-forms?activeTab=versions).
 
 ## When to use Piiano Forms

--- a/sdk/typeorm-encryption/README.md
+++ b/sdk/typeorm-encryption/README.md
@@ -14,7 +14,7 @@ This package extends the `typeorm` package to provide support for encrypting and
 
 > **Note:**
 >
-> This package is compatible with Vault version none.
+> This package is compatible with Vault version 1.11.0.
 > For a version compatible with other versions of Vault, check [other versions of this package](https://www.npmjs.com/package/@piiano/typeorm-encryption?activeTab=versions).
 
 ## Requirements

--- a/sdk/vault-bundles/README.md
+++ b/sdk/vault-bundles/README.md
@@ -4,7 +4,7 @@ This is a TypeScript package that provides type definitions for [Piiano Vault Bu
 
 > **Note:**
 > 
-> This package is compatible with Vault version none.
+> This package is compatible with Vault version 1.11.0.
 > For a Vault client compatible with other versions of Vault, check [other versions of this package](https://www.npmjs.com/package/@piiano/bundles?activeTab=versions).
 
 ## Installation

--- a/sdk/vault-client/README.md
+++ b/sdk/vault-client/README.md
@@ -4,7 +4,7 @@ This is a TypeScript client to connect to a Piiano Vault. It provides an easy-to
 
 > **Note:**
 > 
-> This package is compatible with Vault version none.
+> This package is compatible with Vault version 1.11.0.
 > For a Vault client compatible with other versions of Vault, check [other versions of this package](https://www.npmjs.com/package/@piiano/vault-client?activeTab=versions).
 
 ## Installation


### PR DESCRIPTION
- Revert "Update README.md files to Vault version none"
- fix workflow to not update readmes if vault version is missing
