### PR TITLE
add view copy method and propagate key events

### DIFF
--- a/sdk/forms/README.md
+++ b/sdk/forms/README.md
@@ -241,7 +241,7 @@ When `onClick`, `onMouseEnter`, or `onMouseLeave` hooks are called, the event ob
 
 ###### KeyboardEvent
 
-For convenience sack, when a keyboard event (`keydown`, `keyup`, or `keypress`) occurs in the view, the event object is serialized and dispatched to the hosting page as a regular keyboard event so keybindings defined on the page can be triggered even when the view is focused. The view also adds a `trustedEventKey` property to the event object. This property can be used with the `copy` method to ensure to tell the view that the event was triggered by a trusted source and skip showing the confirmation dialog.
+For simplicity, when a keyboard event (`keydown`, `keyup`, or `keypress`) occurs in the view, the event object is serialized and dispatched to the hosting page as a regular keyboard event so keybindings defined on the page can be triggered even when the view is focused. The view also adds a `trustedEventKey` property to the event object. This property can be used with the `copy` method to ensure that the event was triggered by a trusted source and skip showing the confirmation dialog.
 
 ##### Returned Object
 

--- a/sdk/forms/README.md
+++ b/sdk/forms/README.md
@@ -241,7 +241,7 @@ When `onClick`, `onMouseEnter`, or `onMouseLeave` hooks are called, the event ob
 
 ###### KeyboardEvent
 
-For convenience sack, when a keyboard event (`keydown`, `keyup`, or `keypress`) occurs in the view, the event object is serialized and dispatched to the hosting page as a regular keyboard event so keybindings defined on the page can be triggered even when the view is focused.
+For convenience sack, when a keyboard event (`keydown`, `keyup`, or `keypress`) occurs in the view, the event object is serialized and dispatched to the hosting page as a regular keyboard event so keybindings defined on the page can be triggered even when the view is focused. The view also adds a `trustedEventKey` property to the event object. This property can be used with the `copy` method to ensure to tell the view that the event was triggered by a trusted source and skip showing the confirmation dialog.
 
 ##### Returned Object
 
@@ -249,7 +249,9 @@ The `createProtectedView` function returns a View object that has the following 
 
 - `destroy()`: Removes the view instance from the DOM.
 - `update(options)`: Updates the view’s configuration. For the `update` method to work, the `dynamic` option must be set to `true` in the initial configuration.
-- `copy(path)`: Copies the value of the field at the specified path to the clipboard.
+- `copy(params)`: Copies the value of a specified field to the clipboard. The `params` object should contain the following properties:
+  - `path` (string): Path to the field in the view to copy using JSON path syntax similar to the `display` configuration.
+  - `trustedEventKey` (optional string): A key that indicates the event is trusted and should not show the confirmation dialog. This key should match the `trustedEventKey` property in the event object dispatched by the view on keyboard events. For security reasons, the view will show a confirmation dialog for any other programmatic invocation.
 
 ##### Usage Example
 

--- a/sdk/forms/README.md
+++ b/sdk/forms/README.md
@@ -239,12 +239,17 @@ When `onClick`, `onMouseEnter`, or `onMouseLeave` hooks are called, the event ob
   - `mouseY`: y coordinate of the mouse pointer during the event.
   - `rect`: A [DOMRect](https://developer.mozilla.org/en-US/docs/Web/API/DOMRect) element representing the bounding rectangle of the value element that received the event.
 
+###### KeyboardEvent
+
+For convenience sack, when a keyboard event (`keydown`, `keyup`, or `keypress`) occurs in the view, the event object is serialized and dispatched to the hosting page as a regular keyboard event so keybindings defined on the page can be triggered even when the view is focused.
+
 ##### Returned Object
 
 The `createProtectedView` function returns a View object that has the following methods:
 
 - `destroy()`: Removes the view instance from the DOM.
 - `update(options)`: Updates the view’s configuration. For the `update` method to work, the `dynamic` option must be set to `true` in the initial configuration.
+- `copy(path)`: Copies the value of the field at the specified path to the clipboard.
 
 ##### Usage Example
 

--- a/sdk/forms/examples/view.html
+++ b/sdk/forms/examples/view.html
@@ -117,12 +117,12 @@ For production use, please refer to the official documentation or consult with a
         if (!reveal) revealCard();
       });
 
-      window.addEventListener('keydown', (e) => {
+      window.addEventListener('keydown', async (e) => {
         if (e.key !== 's' || !e.metaKey) return;
 
         e.preventDefault();
+        await view.copy({ path: '[0].card_number', trustedEventKey: e.trustedEventKey });
         revealCard();
-        view.copy('[0].card_number');
       });
     </script>
     <style>

--- a/sdk/forms/examples/view.html
+++ b/sdk/forms/examples/view.html
@@ -107,12 +107,22 @@ For production use, please refer to the official documentation or consult with a
       }
 
       const view = createProtectedView('#view-container', getOptions());
+      function revealCard() {
+        reveal = true;
+        card.classList.add('reveal');
+        view.update(getOptions());
+      }
+
       card.addEventListener('click', () => {
-        if (!reveal) {
-          reveal = true;
-          card.classList.add('reveal');
-          view.update(getOptions());
-        }
+        if (!reveal) revealCard();
+      });
+
+      window.addEventListener('keydown', (e) => {
+        if (e.key !== 's' || !e.metaKey) return;
+
+        e.preventDefault();
+        revealCard();
+        view.copy('[0].card_number');
       });
     </script>
     <style>

--- a/sdk/forms/src/common/models.ts
+++ b/sdk/forms/src/common/models.ts
@@ -350,5 +350,18 @@ export const ViewIframeEventValidator = oneOf(
     event: literal('container-size'),
     payload: SizeValidator,
   }),
+  /**
+   * Trigger a copy event on a field.
+   * Notice this event will also move the focus to the view.
+   */
+  object({
+    event: literal('copy'),
+    payload: object({
+      /**
+       * The field path to copy.
+       */
+      path: string(),
+    }),
+  }),
 );
 export type ViewIframeEvent = Infer<typeof ViewInitOptionsValidator>;

--- a/sdk/forms/src/common/models.ts
+++ b/sdk/forms/src/common/models.ts
@@ -361,6 +361,11 @@ export const ViewIframeEventValidator = oneOf(
        * The field path to copy.
        */
       path: string(),
+
+      /**
+       * For security reasons, the event key must be provided to allow the copy event.
+       */
+      trustedEventKey: string().optional(),
     }),
   }),
 );

--- a/sdk/forms/src/protected-view/iframe/components/view.ts
+++ b/sdk/forms/src/protected-view/iframe/components/view.ts
@@ -135,7 +135,7 @@ export function copy(value: string) {
   document.body.removeChild(input);
 }
 
-function formatValue(value: string | number | boolean, format?: string): string {
+export function formatValue(value: string | number | boolean, format?: string): string {
   const stringValue = String(value);
   if (!format) return stringValue;
 

--- a/sdk/forms/src/protected-view/iframe/components/view.ts
+++ b/sdk/forms/src/protected-view/iframe/components/view.ts
@@ -74,7 +74,7 @@ const DisplayValue = component(
         children.push(span);
         break;
       }
-      case 'object':
+      case 'object': {
         if (value === null) break;
 
         if (Array.isArray(value)) {
@@ -93,6 +93,7 @@ const DisplayValue = component(
           ),
         );
         children.push(object);
+      }
     }
 
     container.replaceChildren(...children);
@@ -110,7 +111,7 @@ const Label = component((_, { label }: { label: string }) => {
   return labelElement;
 });
 
-function copy(value: string) {
+export function copy(value: string) {
   if ('clipboard' in navigator && 'writeText' in navigator.clipboard) {
     navigator.clipboard.writeText(value).catch(() => void 0);
     return;

--- a/sdk/forms/src/protected-view/index.ts
+++ b/sdk/forms/src/protected-view/index.ts
@@ -7,9 +7,23 @@ import { ViewInitOptionsValidator } from '../common/models';
 
 export type { Theme, Style, Variables, Field } from '../common/models';
 
+/**
+ * A view that handle to interact with the protected view iframe programmatically.
+ */
 export type View = {
+  /**
+   * Destroy the view and remove it from the DOM safely.
+   */
   destroy: () => void;
+  /**
+   * Update the view with new options.
+   * Note: the dynamic flag must be true to allow updates.
+   */
   update: (options: ProtectedViewOptions) => void;
+  /**
+   * Copy the value of the specified field path to the clipboard.
+   */
+  copy: (path: string) => Promise<void>;
 };
 
 export function createProtectedView(
@@ -76,6 +90,11 @@ export function createProtectedView(
       hooks = newHooks;
       sendToIframe('update', options);
     },
+    async copy(path: string) {
+      await ready;
+      iframe.contentWindow?.focus();
+      sendToIframe('copy', { path });
+    },
   };
 }
 
@@ -117,6 +136,11 @@ function registerHooks(log: Logger, iframe: HTMLIFrameElement, hooks: ProtectedV
           break;
         case 'mouseleave':
           hooks?.onMouseLeave?.(payload);
+          break;
+        case 'keydown':
+        case 'keyup':
+        case 'keypress':
+          iframe.dispatchEvent(new KeyboardEvent(event, payload));
           break;
       }
     };

--- a/sdk/forms/vite.config.ts
+++ b/sdk/forms/vite.config.ts
@@ -11,7 +11,7 @@ const config: UserConfigFnPromise = async ({ mode }): Promise<UserConfig> => {
   const example = {
     form: '/examples/form.html',
     view: '/examples/view.html',
-  }[process.env.EXAMPLE ?? 'view.html'];
+  }[process.env.EXAMPLE ?? 'view'];
 
   if (mode === 'dev') {
     if (!example) throw new Error('Invalid EXAMPLE env variable');


### PR DESCRIPTION
- Propagate keyboard events from the iframe to the parent so keybindings defined on the host will work even when the iframe is in focus
- Allow to trigger a field value copy programmatically with a new `copy(path)` method on the view handle.
- Update view example to reveal & copy the card number on `Cmd+S`/`Ctrl+S`